### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build and publish Docker image
-        uses: elgohr/Publish-Docker-Github-Action@2.8
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: eddieschoute/luatex-stix/luatex-stix
           username: $GITHUB_ACTOR


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore